### PR TITLE
feat: add feature flags to module configuration

### DIFF
--- a/lib/configurations/module.nix
+++ b/lib/configurations/module.nix
@@ -21,7 +21,7 @@
           if builtins.typeOf x == "lambda"
           then
             x {
-              inherit name cfg;
+              inherit name cfg featured;
               myconfig = config.${myconfigName};
             }
           else x;

--- a/lib/configurations/module.nix
+++ b/lib/configurations/module.nix
@@ -7,6 +7,7 @@
 }: {
   module = {
     name,
+    feature ? null,
     options ? {},
     myconfig ? {},
     nixos ? {},
@@ -28,14 +29,16 @@
         defaults = {
           ifEnabled ? {},
           ifDisabled ? {},
+          ifFeatured ? {},
           always ? {},
-        }: {inherit ifEnabled ifDisabled always;};
+        }: {inherit ifEnabled ifDisabled ifFeatured always;};
         _myconfig = defaults myconfig;
         _nixos = defaults nixos;
         _home = defaults home;
 
         enabled = delib.attrset.getAttrByStrPath "enable" cfg false;
         disabled = !(delib.attrset.getAttrByStrPath "enable" cfg true);
+        featured = lib.lists.elem feature (delib.attrset.getAttrByStrPath "features" cfg [ ]);
       in {
         options.${myconfigName} = wrap options;
 
@@ -43,6 +46,7 @@
           (apply.all (wrap _myconfig.always) (wrap _nixos.always) (wrap _home.always))
           (lib.mkIf enabled (apply.all (wrap _myconfig.ifEnabled) (wrap _nixos.ifEnabled) (wrap _home.ifEnabled)))
           (lib.mkIf disabled (apply.all (wrap _myconfig.ifDisabled) (wrap _nixos.ifDisabled) (wrap _home.ifDisabled)))
+          (lib.mkIf featured (apply.all (wrap _myconfig.ifFeatured) (wrap _nixos.ifFeatured) (wrap _home.ifFeatured)))
         ];
       })
     ];

--- a/lib/configurations/module.nix
+++ b/lib/configurations/module.nix
@@ -38,7 +38,7 @@
 
         enabled = delib.attrset.getAttrByStrPath "enable" cfg false;
         disabled = !(delib.attrset.getAttrByStrPath "enable" cfg true);
-        featured = enabled && lib.lists.elem feature (delib.attrset.getAttrByStrPath "features" cfg [ ]);
+        featured = enabled && lib.lists.elem feature (delib.attrset.getAttrByStrPath "features" cfg []);
       in {
         options.${myconfigName} = wrap options;
 

--- a/lib/configurations/module.nix
+++ b/lib/configurations/module.nix
@@ -38,7 +38,7 @@
 
         enabled = delib.attrset.getAttrByStrPath "enable" cfg false;
         disabled = !(delib.attrset.getAttrByStrPath "enable" cfg true);
-        featured = lib.lists.elem feature (delib.attrset.getAttrByStrPath "features" cfg [ ]);
+        featured = enabled && lib.lists.elem feature (delib.attrset.getAttrByStrPath "features" cfg [ ]);
       in {
         options.${myconfigName} = wrap options;
 

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -76,4 +76,11 @@ in rec {
 
   singleEnableOption = default: {name, ...}:
     delib.attrset.setAttrByStrPath "${name}.enable" (boolOption default);
+
+  featuresEnableOption =
+    defaultEnabled: defaultFeatures: { name, ... }:
+    delib.attrset.setAttrByStrPath name {
+      enable = boolOption defaultEnabled;
+      features = listOfOption str defaultFeatures;
+    };
 }

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -77,8 +77,7 @@ in rec {
   singleEnableOption = default: {name, ...}:
     delib.attrset.setAttrByStrPath "${name}.enable" (boolOption default);
 
-  featuresEnableOption =
-    defaultEnabled: defaultFeatures: { name, ... }:
+  featuresEnableOption = defaultEnabled: defaultFeatures: {name, ...}:
     delib.attrset.setAttrByStrPath name {
       enable = boolOption defaultEnabled;
       features = listOfOption str defaultFeatures;


### PR DESCRIPTION
Adds an `ifFeatured` option to provide granular control over module behavior without requiring full custom configuration. This sits alongside the existing enable flag, allowing for more flexible module control while maintaining simplicity.

[Example configuration can be found here](https://github.com/mzonski/denix-demo/commit/ea35f49f16473a59550a12f89a31a86e28b60f9c)

This results in proper feature flag evaluation, as shown in the trace output:
```
❯ home-manager build --flake .#zonni@desktop --show-trace
trace: foooobar/c2_foo feature enabled
trace: child1/c1_baz feature enabled
trace: child1/c1_bar feature enabled
trace: child2 (foooobar) feature enabled
trace: child1 feature enabled
```

What do you think about this change?