### PR TITLE
fix type of `system.stateVersion' to integer.

### DIFF
--- a/templates/minimal-no-rices/hosts/desktop/hardware.nix
+++ b/templates/minimal-no-rices/hosts/desktop/hardware.nix
@@ -17,6 +17,6 @@ delib.host {
   # If you're not using Nix-Darwin, you can remove this entire block.
   darwin = {
     nixpkgs.hostPlatform = "aarch64-darwin"; #!!! REPLACEME
-    system.stateVersion = "6"; #!!! REPLACEME
+    system.stateVersion = 6; #!!! REPLACEME
   };
 }

--- a/templates/minimal/hosts/desktop/hardware.nix
+++ b/templates/minimal/hosts/desktop/hardware.nix
@@ -17,6 +17,6 @@ delib.host {
   # If you're not using Nix-Darwin, you can remove this entire block.
   darwin = {
     nixpkgs.hostPlatform = "aarch64-darwin"; #!!! REPLACEME
-    system.stateVersion = "6"; #!!! REPLACEME
+    system.stateVersion = 6; #!!! REPLACEME
   };
 }


### PR DESCRIPTION
fix type (string to integer).

```
error: A definition for option `system.stateVersion' is not of type
`integer between 1 and 6 (both inclusive)'. Definition values:       -
In
`/nix/store/7qjpd6asiwb1p10ijrnjjq8vrhcyr0g3-source/templates/minimal/hosts/desktop/hardware.nix':
"6"
```