### PR TITLE
Feature: add `nixpkgs`, `home-manager`, and `nix-darwin` arguments to `delib.configurations`

### DIFF
--- a/docs/src/configurations/introduction.md
+++ b/docs/src/configurations/introduction.md
@@ -47,3 +47,149 @@ in {
   darwinConfigurations = mkConfigurations "darwin";
 }
 ```
+
+## Using multiple channels {#multiple-channels}
+To conveniently work with multiple channels in the configuration, the `delib.configurations` function accepts the arguments `nixpkgs`, `home-manager`, and `nix-darwin`, which are used in the generated configurations.
+
+**By default, there is no need to specify these arguments** - they default to the corresponding values from the Denix flake's `inputs`. These can also be overridden via `inputs.denix.inputs.<input>.follows`, which is more convenient for users who rely on a single channel.
+
+Therefore:
+- `delib.configurations :: [nixpkgs, home-manager, nix-darwin]` - for those who need multiple channels.
+- `inputs.denix.<nixpkgs|home-manager|nix-darwin>.follows` - for those who only need a single channel.
+
+Based on this, several usage options are possible:
+
+1. Override `nixpkgs`, `home-manager`, and `nix-darwin` via the arguments of the `delib.configurations` function for both "stable" and "unstable" channels used in `./hosts/stable` and `./hosts/unstable`, respectively. Note that the implementation of the `mkConfigurations` function can vary - this is just an example.
+```nix
+{
+  inputs = {
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.05";
+
+    home-manager-unstable = {
+      url = "github:nix-community/home-manager/master";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
+    home-manager-stable = {
+      url = "github:nix-community/home-manager/release-25.05";
+      inputs.nixpkgs.follows = "nixpkgs-stable";
+    };
+
+    nix-darwin-unstable = {
+      url = "github:nix-darwin/nix-darwin/master";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
+    nix-darwin-stable = {
+      url = "github:nix-darwin/nix-darwin/nix-darwin-25.05";
+      inputs.nixpkgs.follows = "nixpkgs-stable";
+    };
+
+    denix.url = "github:yunfachi/denix";
+  };
+
+  outputs = {
+    denix,
+    nixpkgs-unstable,
+    nixpkgs-stable,
+    home-manager-unstable,
+    home-manager-stable,
+    nix-darwin-unstable,
+    nix-darwin-stable,
+    ...
+  } @ inputs: let
+    _mkConfigurations = nixpkgs: home-manager: nix-darwin: hosts: moduleSystem:
+      denix.lib.configurations {
+        inherit moduleSystem nixpkgs home-manager nix-darwin;
+        homeManagerUser = "sjohn";
+
+        paths = [./modules ./rices] ++ hosts;
+
+        specialArgs = {
+          inherit inputs;
+        };
+      };
+
+    mkConfigurations = moduleSystem:
+      nixpkgs-unstable.lib.attrsets.mergeAttrsList 
+      (map (f: f moduleSystem) [
+        (_mkConfigurations nixpkgs-stable home-manager-stable nix-darwin-stable [./hosts/stable])
+        (_mkConfigurations nixpkgs-unstable home-manager-unstable nix-darwin-unstable [./hosts/unstable])
+      ]);
+  in {
+    nixosConfigurations = mkConfigurations "nixos";
+    homeConfigurations = mkConfigurations "home";
+    darwinConfigurations = mkConfigurations "darwin";
+  };
+}
+```
+
+2. Override `nixpkgs`, `home-manager`, and `nix-darwin` using `inputs.denix.inputs.<name>.follows`. This is the recommended method for those using a single channel.
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+    home-manager = {
+      url = "github:nix-community/home-manager/master";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nix-darwin = {
+      url = "github:nix-darwin/nix-darwin/master";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    denix = {
+      url = "github:yunfachi/denix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.home-manager.follows = "home-manager";
+      inputs.nix-darwin.follows = "nix-darwin";
+    };
+  };
+
+  outputs = {denix, ...} @ inputs: let
+    mkConfigurations = moduleSystem:
+      denix.lib.configurations {
+        inherit moduleSystem;
+        homeManagerUser = "sjohn";
+
+        paths = [./hosts ./modules ./rices];
+
+        specialArgs = {
+          inherit inputs;
+        };
+      };
+  in {
+    nixosConfigurations = mkConfigurations "nixos";
+    homeConfigurations = mkConfigurations "home";
+    darwinConfigurations = mkConfigurations "darwin";
+  };
+}
+```
+
+3. Do not override anything. Also suitable for single-channel use, though less recommended.
+```nix
+{
+  inputs = {
+    denix.url = "github:yunfachi/denix";
+  };
+
+  outputs = {denix, ...} @ inputs: let
+    mkConfigurations = moduleSystem:
+      denix.lib.configurations {
+        inherit moduleSystem;
+        homeManagerUser = "sjohn";
+
+        paths = [./hosts ./modules ./rices];
+
+        specialArgs = {
+          inherit inputs;
+        };
+      };
+  in {
+    nixosConfigurations = mkConfigurations "nixos";
+    homeConfigurations = mkConfigurations "home";
+    darwinConfigurations = mkConfigurations "darwin";
+  };
+}
+```

--- a/docs/src/configurations/structure.md
+++ b/docs/src/configurations/structure.md
@@ -1,24 +1,30 @@
 # Structure {#structure}
 
 ## Function Arguments {#function-arguments}
-- `myconfigName` (string): the category for all Denix module options, hosts, and rices. Default is `myconfig`; changes are not recommended.
-- `denixLibName` (string): the name of the Denix library in `specialArgs` (`{denixLibName, ...}: denixLibName.module { ... }`). Default is `delib`; changes are not recommended.
-- `homeManagerNixpkgs` (nixpkgs): used in the `pkgs` attribute of the `home-manager.lib.homeManagerConfiguration` function in the format: `homeManagerNixpkgs.legacyPackages.${host :: homeManagerSystem}`. By default, it takes `nixpkgs` from the flake, so if you've set `inputs.denix.inputs.nixpkgs.follows = "nixpkgs";`, specifying `homeManagerNixpkgs` is typically unnecessary.
+- `myconfigName` (string): the category for all Denix module options, hosts, and rices. Defaults to `myconfig`; changes are not recommended.
+- `denixLibName` (string): the name of the Denix library in `specialArgs` (`{denixLibName, ...}: denixLibName.module { ... }`). Defaults to `delib`; changes are not recommended.
+- `nixpkgs` (nixpkgs): used to override nixpkgs in your configuration, equivalent to `inputs.denix.inputs.nixpkgs.follows`. Defaults to `inputs.nixpkgs`.
+- `home-manager` (home-manager): used to override home-manager in your configuration, equivalent to `inputs.denix.inputs.home-manager.follows`. Defaults to `inputs.home-manager`.
+- `nix-darwin` (nix-darwin): used to override nix-darwin in your configuration, equivalent to `inputs.denix.inputs.nix-darwin.follows`. Defaults to `inputs.nix-darwin`.
+- `homeManagerNixpkgs` (nixpkgs): used in the `pkgs` attribute of the `home-manager.lib.homeManagerConfiguration` function in the format: `homeManagerNixpkgs.legacyPackages.${host :: homeManagerSystem}`. Defaults to the `nixpkgs` provided in the function arguments.
 - `homeManagerUser` (string): the username, used in `home-manager.users.${homeManagerUser}` and for generating the Home Manager configuration list.
 - `moduleSystem` ("nixos", "home", and "darwin"): specifies which module system the configuration list should be generated for - NixOS, Home Manager, or Nix-Darwin.
-- `paths` (listOf string): paths to be imported; add hosts, rices, and modules here. Default is `[]`.
-- `exclude` (listOf string): paths to be excluded from importing. Default is `[]`.
-- `recursive` (boolean): determines whether to recursively search for paths to import. Default is `true`.
-- `specialArgs` (attrset): `specialArgs` to be passed to `lib.nixosSystem`, `home-manager.lib.homeManagerConfiguration`, and `nix-darwin.lib.darwinSystem`. Default is `{}`.
-- **EXPERIMENTAL** `extraModules` (list): default is `[]`.
-- **EXPERIMENTAL** `mkConfigurationsSystemExtraModule` (attrset): a module used in the internal NixOS configuration that receives the list of hosts and rices to generate the configuration list. Default is `{nixpkgs.hostPlatform = "x86_64-linux";}`.
+- `paths` (listOf string): paths to be imported; add hosts, rices, and modules here. Defaults to `[]`.
+- `exclude` (listOf string): paths to be excluded from importing. Defaults to `[]`.
+- `recursive` (boolean): determines whether to recursively search for paths to import. Defaults to `true`.
+- `specialArgs` (attrset): `specialArgs` to be passed to `lib.nixosSystem`, `home-manager.lib.homeManagerConfiguration`, and `nix-darwin.lib.darwinSystem`. Defaults to `{}`.
+- **EXPERIMENTAL** `extraModules` (list): defaults to `[]`.
+- **EXPERIMENTAL** `mkConfigurationsSystemExtraModule` (attrset): a module used in the internal NixOS configuration that receives the list of hosts and rices to generate the configuration list. Defaults to `{nixpkgs.hostPlatform = "x86_64-linux";}`.
 
 ## Pseudocode {#pseudocode}
 ```nix
-delib.configurations {
+delib.configurations rec {
   myconfigName = "myconfig";
   denixLibName = "delib";
-  homeManagerNixpkgs = inputs.nixpkgs;
+  nixpkgs = inputs.nixpkgs;
+  home-manager = inputs.home-manager;
+  nix-darwin = inputs.nix-darwin;
+  homeManagerNixpkgs = nixpkgs;
   homeManagerUser = "sjohn";
   moduleSystem = "nixos";
   paths = [./modules ./hosts ./rices];
@@ -28,3 +34,4 @@ delib.configurations {
     inherit inputs;
   };
 }
+```

--- a/docs/src/ru/configurations/introduction.md
+++ b/docs/src/ru/configurations/introduction.md
@@ -47,3 +47,149 @@ in {
   darwinConfigurations = mkConfigurations "darwin";
 }
 ```
+
+## Использование нескольких каналов {#multiple-channels}
+Для удобной работы с несколькими каналами в конфигурации функция `delib.configurations` принимает аргументы `nixpkgs`, `home-manager` и `nix-darwin`, которые используются в сгенерированных конфигурациях.
+
+**По умолчанию эти аргументы указывать не требуется** - они равны соответствующим значениям из `inputs` флейка Denix. Эти значения можно также переопределить через `inputs.denix.inputs.<input>.follows`, однако такой способ больше подходит тем, кто использует только один канал.
+
+Таким образом:
+- `delib.configurations :: [nixpkgs, home-manager, nix-darwin]` - для тех, кому нужно несколько каналов.
+- `inputs.denix.<nixpkgs|home-manager|nix-darwin>.follows` - для тех, кому достаточно одного канала.
+
+Исходя из этого, возможны следующие варианты использования:
+
+1. Переопределение `nixpkgs`, `home-manager` и `nix-darwin` через аргументы функции `delib.configurations` на каналы "stable" и "unstable" для `./hosts/stable` и `./hosts/unstable` соответственно. Обратите внимание, что реализация функции `mkConfigurations` в этом примере может быть произвольной - это лишь демонстрация подхода.
+```nix
+{
+  inputs = {
+    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.05";
+
+    home-manager-unstable = {
+      url = "github:nix-community/home-manager/master";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
+    home-manager-stable = {
+      url = "github:nix-community/home-manager/release-25.05";
+      inputs.nixpkgs.follows = "nixpkgs-stable";
+    };
+
+    nix-darwin-unstable = {
+      url = "github:nix-darwin/nix-darwin/master";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+    };
+    nix-darwin-stable = {
+      url = "github:nix-darwin/nix-darwin/nix-darwin-25.05";
+      inputs.nixpkgs.follows = "nixpkgs-stable";
+    };
+
+    denix.url = "github:yunfachi/denix";
+  };
+
+  outputs = {
+    denix,
+    nixpkgs-unstable,
+    nixpkgs-stable,
+    home-manager-unstable,
+    home-manager-stable,
+    nix-darwin-unstable,
+    nix-darwin-stable,
+    ...
+  } @ inputs: let
+    _mkConfigurations = nixpkgs: home-manager: nix-darwin: hosts: moduleSystem:
+      denix.lib.configurations {
+        inherit moduleSystem nixpkgs home-manager nix-darwin;
+        homeManagerUser = "sjohn";
+
+        paths = [./modules ./rices] ++ hosts;
+
+        specialArgs = {
+          inherit inputs;
+        };
+      };
+
+    mkConfigurations = moduleSystem:
+      nixpkgs-unstable.lib.attrsets.mergeAttrsList 
+      (map (f: f moduleSystem) [
+        (_mkConfigurations nixpkgs-stable home-manager-stable nix-darwin-stable [./hosts/stable])
+        (_mkConfigurations nixpkgs-unstable home-manager-unstable nix-darwin-unstable [./hosts/unstable])
+      ]);
+  in {
+    nixosConfigurations = mkConfigurations "nixos";
+    homeConfigurations = mkConfigurations "home";
+    darwinConfigurations = mkConfigurations "darwin";
+  };
+}
+```
+
+2. Переопределение `nixpkgs`, `home-manager` и `nix-darwin` через `inputs.denix.inputs.<name>.follows`. Это рекомендуемый способ для тех, кто использует только один канал.
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+    home-manager = {
+      url = "github:nix-community/home-manager/master";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nix-darwin = {
+      url = "github:nix-darwin/nix-darwin/master";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    denix = {
+      url = "github:yunfachi/denix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.home-manager.follows = "home-manager";
+      inputs.nix-darwin.follows = "nix-darwin";
+    };
+  };
+
+  outputs = {denix, ...} @ inputs: let
+    mkConfigurations = moduleSystem:
+      denix.lib.configurations {
+        inherit moduleSystem;
+        homeManagerUser = "sjohn";
+
+        paths = [./hosts ./modules ./rices];
+
+        specialArgs = {
+          inherit inputs;
+        };
+      };
+  in {
+    nixosConfigurations = mkConfigurations "nixos";
+    homeConfigurations = mkConfigurations "home";
+    darwinConfigurations = mkConfigurations "darwin";
+  };
+}
+```
+
+3. Не переопределять ничего. Также вариант для использования одного канала, но менее рекомендуемый.
+```nix
+{
+  inputs = {
+    denix.url = "github:yunfachi/denix";
+  };
+
+  outputs = {denix, ...} @ inputs: let
+    mkConfigurations = moduleSystem:
+      denix.lib.configurations {
+        inherit moduleSystem;
+        homeManagerUser = "sjohn";
+
+        paths = [./hosts ./modules ./rices];
+
+        specialArgs = {
+          inherit inputs;
+        };
+      };
+  in {
+    nixosConfigurations = mkConfigurations "nixos";
+    homeConfigurations = mkConfigurations "home";
+    darwinConfigurations = mkConfigurations "darwin";
+  };
+}
+```

--- a/docs/src/ru/configurations/structure.md
+++ b/docs/src/ru/configurations/structure.md
@@ -3,7 +3,10 @@
 ## Аргументы функции {#function-arguments}
 - `myconfigName` (string): категория для всех опций модулей Denix, хостов и райсов. По умолчанию `myconfig`; изменять не рекомендуется.
 - `denixLibName` (string): имя библиотеки Denix в `specialArgs` (`{denixLibName, ...}: denixLibName.module { ... }`). По умолчанию `delib`; изменять не рекомендуется.
-- `homeManagerNixpkgs` (nixpkgs): используется в атрибуте `pkgs` функции `home-manager.lib.homeManagerConfiguration` в формате: `homeManagerNixpkgs.legacyPackages.${host :: homeManagerSystem}`. По умолчанию берется `nixpkgs` из флейка, поэтому если вы указали `inputs.denix.inputs.nixpkgs.follows = "nixpkgs";`, указывать `homeManagerNixpkgs` обычно не имеет смысла.
+- `nixpkgs` (nixpkgs): используется для переопределения nixpkgs в вашей конфигурации, аналогично `inputs.denix.inputs.nixpkgs.follows`. По умолчанию `inputs.nixpkgs`.
+- `home-manager` (home-manager): используется для переопределения home-manager в вашей конфигурации, аналогично `inputs.denix.inputs.home-manager.follows`. По умолчанию `inputs.home-manager`.
+- `nix-darwin` (nix-darwin): используется для переопределения nix-darwin в вашей конфигурации, аналогично `inputs.denix.inputs.nix-darwin.follows`. По умолчанию `inputs.nix-darwin`.
+- `homeManagerNixpkgs` (nixpkgs): используется в атрибуте `pkgs` функции `home-manager.lib.homeManagerConfiguration` в формате: `homeManagerNixpkgs.legacyPackages.${host :: homeManagerSystem}`. По умолчанию используется `nixpkgs` из аргументов этой функции.
 - `homeManagerUser` (string): имя пользователя, используется в `home-manager.users.${homeManagerUser}` и для генерации списка конфигураций Home Manager.
 - `moduleSystem` (`"nixos"`, `"home"` и `"darwin"`): указывает, для какой модульной системы должен быть создан список конфигураций - NixOS, Home Manager или Nix-Darwin.
 - `paths` (listOf string): пути, которые будут импортированы; добавьте сюда хосты, райсы и модули. По умолчанию `[]`.
@@ -15,10 +18,13 @@
 
 ## Псевдокод {#pseudocode}
 ```nix
-delib.configurations {
+delib.configurations rec {
   myconfigName = "myconfig";
   denixLibName = "delib";
-  homeManagerNixpkgs = inputs.nixpkgs;
+  nixpkgs = inputs.nixpkgs;
+  home-manager = inputs.home-manager;
+  nix-darwin = inputs.nix-darwin;
+  homeManagerNixpkgs = nixpkgs;
   homeManagerUser = "sjohn";
   moduleSystem = "nixos";
   paths = [./modules ./hosts ./rices];

--- a/flake.lock
+++ b/flake.lock
@@ -94,13 +94,42 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1749345370,
+        "narHash": "sha256-w2J8aeSsMT6v6xAokr076vSCDHs5LRi2JkTUyNsEl4o=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "2a3d74c76852805ec8eba6dd52350e85e75805ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1749213349,
+        "narHash": "sha256-UAaWOyQhdp7nXzsbmLVC67fo+QetzoTm9hsPf9X3yr4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a4ff0e3c64846abea89662bfbacf037ef4b34207",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
         "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1746537231,
@@ -121,6 +150,7 @@
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-lib": "nixpkgs-lib",
         "pre-commit-hooks": "pre-commit-hooks"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,11 @@
   description = "Nix library for creating scalable NixOS, Home Manager, and Nix-Darwin configurations with modules, hosts, and rices.";
 
   inputs = {
+    nixpkgs-lib.url = "github:nix-community/nixpkgs.lib";
+    pre-commit-hooks = {
+      url = "github:cachix/git-hooks.nix";
+    };
+
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     home-manager = {
       url = "github:nix-community/home-manager/master";
@@ -11,26 +16,23 @@
       url = "github:nix-darwin/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    pre-commit-hooks = {
-      url = "github:cachix/git-hooks.nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs = {
     self,
+    nixpkgs-lib,
+    pre-commit-hooks,
     nixpkgs,
     home-manager,
     nix-darwin,
-    pre-commit-hooks,
     ...
   }: let
     supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
 
-    forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    forAllSystems = nixpkgs-lib.lib.genAttrs supportedSystems;
   in {
     lib = import ./lib {
-      inherit (nixpkgs) lib;
+      inherit (nixpkgs-lib) lib;
       inherit home-manager nix-darwin nixpkgs;
     };
 

--- a/lib/configurations/default.nix
+++ b/lib/configurations/default.nix
@@ -5,10 +5,13 @@
   home-manager,
   nix-darwin,
   ...
-}: let
+} @ args: let
   configurations = {
     myconfigName ? "myconfig",
     denixLibName ? "delib",
+    nixpkgs ? args.nixpkgs,
+    home-manager ? args.home-manager,
+    nix-darwin ? args.nix-darwin,
     homeManagerNixpkgs ? nixpkgs,
     homeManagerUser,
     moduleSystem ? null, # TODO: remove the default value once the deprecated isHomeManager is removed
@@ -64,7 +67,7 @@
         currentHostName,
         internalExtraModules ? (moduleSystem_: []),
       }: let
-        nixosSystem = lib.nixosSystem {
+        nixosSystem = nixpkgs.lib.nixosSystem {
           specialArgs =
             specialArgs
             // {


### PR DESCRIPTION
- [x] documentation (configurations structure)
- [x] documentation (configurations introduction)