### PR TITLE
docs: fix showcase link

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -116,7 +116,7 @@ function themeConfigEnglish() {
           ],
         },
         { text: "Common Errors", link: "/troubleshooting" },
-        { text: "Real Configurations", link: "/showcase" },
+        { text: "Showcase", link: "/showcase" },
       ],
     }
   }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -116,7 +116,7 @@ function themeConfigEnglish() {
           ],
         },
         { text: "Common Errors", link: "/troubleshooting" },
-        { text: "Real Configurations", link: "/real-configurations" },
+        { text: "Real Configurations", link: "/showcase" },
       ],
     }
   }
@@ -199,7 +199,7 @@ function themeConfigRussian() {
           ],
         },
         { text: "Распространённые ошибки", link: "/ru/troubleshooting" },
-        { text: "Реальные конфигурации", link: "/ru/real-configurations" },
+        { text: "Реальные конфигурации", link: "/ru/showcase" },
       ],
     }
   }


### PR DESCRIPTION
Fix for incorrect showcase link.

<img width="920" height="548" alt="Screenshot 2025-07-25 at 10 35 35 am" src="https://github.com/user-attachments/assets/23d09d2c-9d3a-48ea-b524-1a4fab4d2949" />
