### PR TITLE
lib/attrset: fix missing splitStrPath

### DIFF
--- a/lib/attrset.nix
+++ b/lib/attrset.nix
@@ -4,9 +4,9 @@
 
   getAttrByStrPath =
     strPath: attrset: default:
-    lib.attrByPath (delib.splitStrPath strPath) default attrset;
+    lib.attrByPath (delib.attrset.splitStrPath strPath) default attrset;
 
-  setAttrByStrPath = strPath: value: lib.setAttrByPath (delib.splitStrPath strPath) value;
+  setAttrByStrPath = strPath: value: lib.setAttrByPath (delib.attrset.splitStrPath strPath) value;
 
   hasAttrs =
     attrs: attrset:


### PR DESCRIPTION
pretty urgent.

fixes 725ae3a...caab272 from #53. otherwise doesn't even build and gives "missing attribute" error. happens.

maybe `delib.attrset` can be defined as self to avoid repetition, but that seems like walking in circles