### PR TITLE
lib/options: add moduleOptions

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -117,4 +117,6 @@ rec {
     default: { name, ... }: delib.attrset.setAttrByStrPath "${name}.enable" (boolOption default);
 
   singleCascadeEnableOption = args: delib.singleEnableOption args.parent.enable args;
+
+  moduleOptions = opts: args: delib.attrset.setAttrByStrPath args.name opts;
 }


### PR DESCRIPTION
addresses #52.

i wanted to implement it as an extension, but this is very simple wrapper, so making it a separate extension feels like an overkill to me (an extension with literally one `libExtension.moduleOptions` function provided...).

this can be done as an extension if we don't want to write the `with delib; moduleOptions` every time; we can make an extension this way that it overrides every single `options` value from every `delib.module`, but:

- it reduces the composability of the library, because what will you do if you want to define an option on an upper level?
- why

so making a built-in wrapper which explicitly says "the following options are for the current module" i think is the most straightforward and simple approach in this case.

as for the naming, i got an error if i tried to use `delib.options` as the name (`expected a set but found a function "lambda options @ ..."`, probably something is overriding it), but `delib.moduleOptions` works. this variant first came to my mind, but maybe something like `cfgOptions` is better, because it "provides" options for the passed `cfg` variable.

i tested it in my configuration. some examples of usage:

```nix
{ delib, pkgs, ... }:
delib.module {
    name = "gpg";

    # no args provided
    options =
        with delib;
        moduleOptions {
            enable = boolOption true;
        };

    home.ifEnabled = {
        programs.gpg.enable = true;
        services.gpg-agent = {
            enable = true;
            pinentry.package = pkgs.pinentry-curses;
        };
    };
}
```

```nix
{ lib, delib, ... }:
delib.module {
    name = "git";

    # nested options with args
    options =
        { myconfig, parent, ... }@args:
        with delib;
        moduleOptions {
            enable = boolOption parent.enable;

            name = noDefault (strOption null);
            email = noDefault (strOption null);

            signing = {
                gpg = boolOption myconfig.gpg.enable;
                key = noDefault (strOption null);
            };
        } args;

    # skipped
}
```

```nix
{ delib, ... }:
delib.module {
    # name is nested, but options syntax doesn't require a path
    name = "git.delta";

    # this can be done with `delib.singleCascadeEnableOption`,
    # but with this approach new options could be provided effortlessly
    options =
        { parent, ... }@args:
        with delib;
        moduleOptions {
            enable = boolOption parent.enable;
        } args;

    home.ifEnabled = {
        programs.git.delta = {
            enable = true;
            options = {
                navigate = true;
                side-by-side = true;
                line-numbers = true;
            };
        };
    };
}
```