### PR TITLE
fix(docs): use semantic HTML table structure

### DIFF
--- a/docs/src/extensions/all-extensions.md
+++ b/docs/src/extensions/all-extensions.md
@@ -3,18 +3,20 @@ This section describes all official Denix extensions.
 
 ## Args {#args}
 <table class="extension-table">
-  <tr>
-    <th>Name</th>
-    <td><code>args</code></td>
-  </tr>
-  <tr>
-    <th>Description</th>
-    <td>More convenient way to configure <code>_module.args</code> via <code>myconfig</code></td>
-  </tr>
-  <tr>
-    <th>Maintainers</th>
-    <td>yunfachi (<a href='https://github.com/yunfachi'>GitHub</a>, <a href='https://t.me/yunfachi'>Telegram</a>)</td>
-  </tr>
+  <tbody>
+    <tr>
+      <th>Name</th>
+      <td><code>args</code></td>
+    </tr>
+    <tr>
+      <th>Description</th>
+      <td>More convenient way to configure <code>_module.args</code> via <code>myconfig</code></td>
+    </tr>
+    <tr>
+      <th>Maintainers</th>
+      <td>yunfachi (<a href='https://github.com/yunfachi'>GitHub</a>, <a href='https://t.me/yunfachi'>Telegram</a>)</td>
+    </tr>
+  </tbody>
 </table>
 
 ### Settings {#args-settings}
@@ -24,18 +26,20 @@ This section describes all official Denix extensions.
 
 ## Base {#base}
 <table class="extension-table">
-  <tr>
-    <th>Name</th>
-    <td><code>base</code></td>
-  </tr>
-  <tr>
-    <th>Description</th>
-    <td>Creates feature-rich and fine-tunable modules for hosts and rices with minimal effort</td>
-  </tr>
-  <tr>
-    <th>Maintainers</th>
-    <td>yunfachi (<a href='https://github.com/yunfachi'>GitHub</a>, <a href='https://t.me/yunfachi'>Telegram</a>)</td>
-  </tr>
+  <tbody>
+    <tr>
+      <th>Name</th>
+      <td><code>base</code></td>
+    </tr>
+    <tr>
+      <th>Description</th>
+      <td>Creates feature-rich and fine-tunable modules for hosts and rices with minimal effort</td>
+    </tr>
+    <tr>
+      <th>Maintainers</th>
+      <td>yunfachi (<a href='https://github.com/yunfachi'>GitHub</a>, <a href='https://t.me/yunfachi'>Telegram</a>)</td>
+    </tr>
+  </tbody>
 </table>
 
 ### Settings {#base-settings}

--- a/docs/src/ru/extensions/all-extensions.md
+++ b/docs/src/ru/extensions/all-extensions.md
@@ -3,18 +3,20 @@
 
 ## Args {#args}
 <table class="extension-table">
-  <tr>
-    <th>Название</th>
-    <td><code>args</code></td>
-  </tr>
-  <tr>
-    <th>Описание</th>
-    <td>Более удобный способ задавать значение <code>_module.args</code> с помощью <code>myconfig</code></td>
-  </tr>
-  <tr>
-    <th>Ответственные</th>
-    <td>yunfachi (<a href='https://github.com/yunfachi'>GitHub</a>, <a href='https://t.me/yunfachi'>Telegram</a>)</td>
-  </tr>
+  <tbody>
+    <tr>
+      <th>Название</th>
+      <td><code>args</code></td>
+    </tr>
+    <tr>
+      <th>Описание</th>
+      <td>Более удобный способ задавать значение <code>_module.args</code> с помощью <code>myconfig</code></td>
+    </tr>
+    <tr>
+      <th>Ответственные</th>
+      <td>yunfachi (<a href='https://github.com/yunfachi'>GitHub</a>, <a href='https://t.me/yunfachi'>Telegram</a>)</td>
+    </tr>
+  </tbody>
 </table>
 
 ### Настройки {#args-settings}
@@ -24,18 +26,20 @@
 
 ## Base {#base}
 <table class="extension-table">
-  <tr>
-    <th>Название</th>
-    <td><code>base</code></td>
-  </tr>
-  <tr>
-    <th>Описание</th>
-    <td>Создаёт функциональные и тонко настраиваемые модули для хостов и райсов с минимальными усилиями</td>
-  </tr>
-  <tr>
-    <th>Ответственные</th>
-    <td>yunfachi (<a href='https://github.com/yunfachi'>GitHub</a>, <a href='https://t.me/yunfachi'>Telegram</a>)</td>
-  </tr>
+  <tbody>
+    <tr>
+      <th>Название</th>
+      <td><code>base</code></td>
+    </tr>
+    <tr>
+      <th>Описание</th>
+      <td>Создаёт функциональные и тонко настраиваемые модули для хостов и райсов с минимальными усилиями</td>
+    </tr>
+    <tr>
+      <th>Ответственные</th>
+      <td>yunfachi (<a href='https://github.com/yunfachi'>GitHub</a>, <a href='https://t.me/yunfachi'>Telegram</a>)</td>
+    </tr>
+  </tbody>
 </table>
 
 ### Настройки {#base-settings}


### PR DESCRIPTION
Currently, when developing documentation, loading the all-extensions.md file causes vitepress to emit a warning about incorrect HTML semantics:

```
08:43:04 [vitepress] warning: <tr> cannot be child of <table>, according to HTML specifications. This can cause hydration errors or potentially disrupt future functionality.
46 |      <td>Creates feature-rich and fine-tunable modules for hosts and rices with minimal effort</td>
47 |    </tr>
48 |    <tr>
   |    ^^^^
49 |      <th>Maintainers</th>
   |  ^^^^^^^^^^^^^^^^^^^^^^^^
50 |      <td>yunfachi (<a href='https://github.com/yunfachi'>GitHub</a>, <a href='https://t.me/yunfachi'>Telegram</a>)</td>
   |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
51 |    </tr>
   |  ^^^^^^^
```

This commit resolves the issue by implementing proper HTML table structure, ensuring compliance with HTML specifications, thus removing warnings from the console.