### PR TITLE
fix(configurations): allow disabling Home Manager without user

### DIFF
--- a/lib/configurations/host.nix
+++ b/lib/configurations/host.nix
@@ -91,7 +91,7 @@
     name = noDefault (strOption null);
 
     useHomeManagerModule = boolOption useHomeManagerModule;
-    homeManagerUser = noNullDefault (strOption homeManagerUser);
+    homeManagerUser = allowNull (strOption homeManagerUser);
     homeManagerSystem = description (noDefault (strOption null)) "Passed to the `homeManagerConfiguration` as `nixpkgs.legacyPackages.<homeManagerSystem>`";
 
     myconfig = attrsOption { };


### PR DESCRIPTION
When `useHomeManagerModule` is false, NixOS and nix-darwin configurations should not require `homeManagerUser`.

  Currently, omitting `homeManagerUser` still fails even with `useHomeManagerModule = false`, because the host option uses `noNullDefault` around `homeManagerUser`. If the top-level value is omitted, the host option has no default at all, so evaluating `host.homeManagerUser` fails before Home Manager integration matters.

  Use a nullable string option instead. This preserves `null` as the default, lets configurations with Home Manager disabled evaluate without a user,  and still allows the existing `mkSystem` check to reject missing users when Home Manager is actually needed.